### PR TITLE
Add Google verification for ScotlandPHP Youtube account

### DIFF
--- a/google6394b321ef39110a.html
+++ b/google6394b321ef39110a.html
@@ -1,0 +1,1 @@
+google-site-verification: google6394b321ef39110a.html


### PR DESCRIPTION
In order to add a verified link to the videos, this verification of domain ownership has to be done.
